### PR TITLE
Changed raMean decMean into RaMean DecMean

### DIFF
--- a/src/utils/finder_chart.py
+++ b/src/utils/finder_chart.py
@@ -130,8 +130,8 @@ def query_ps1_catalogue(ra, dec, radius_deg, minmag=15, maxmag=18.5):
 
     
     newcat = np.zeros(len(catalog), dtype=[("ra", np.double), ("dec", np.double), ("mag", np.float)])
-    newcat["ra"] = catalog["raMean"]
-    newcat["dec"] = catalog["decMean"]
+    newcat["ra"] = catalog["RaMean"]
+    newcat["dec"] = catalog["DecMean"]
     newcat["mag"] = catalog["rMeanPSFMag"]
     
     return newcat


### PR DESCRIPTION
Hi Nadia, the finder_chart.py code has problems working today because of the key names. I fixed it simply changing catalog['raMean'] into catalog['RaMean'] and catalog['decMean'] into catalog['DecMean']. Could you try which version works for you before taking action on the pull reuest?